### PR TITLE
Fixes for Invalid Index errors.

### DIFF
--- a/AirMessage/AppleScript/AppleScriptSource/FaceTime/acceptPendingUser.applescript
+++ b/AirMessage/AppleScript/AppleScriptSource/FaceTime/acceptPendingUser.applescript
@@ -3,11 +3,15 @@
 tell application "System Events"
 	tell process "FaceTime"
 		repeat with groupEl in groups of list 1 of list 1 of scroll area 2 of window 1
-			if (exists attribute "AXIdentifier" of groupEl) and (value of attribute "AXIdentifier" of groupEl = "InCallControlsPendingParticipantCell") then
-				--Accept the user
-				click button 2 of groupEl
-				return true
-			end if
+			try
+				if (exists attribute "AXIdentifier" of groupEl) and (value of attribute "AXIdentifier" of groupEl = "InCallControlsPendingParticipantCell") then
+					repeat while exists button 2 of groupEl
+						--Accept the user
+						click button 2 of groupEl
+					end repeat
+					return true
+				end if
+			end try
 		end repeat
 		
 		return false

--- a/AirMessage/AppleScript/AppleScriptSource/FaceTime/getActiveLink.applescript
+++ b/AirMessage/AppleScript/AppleScriptSource/FaceTime/getActiveLink.applescript
@@ -8,7 +8,7 @@ tell application "System Events"
 	tell process "FaceTime"
 		set windowReady to false
 		repeat while not windowReady
-			if exists window 1
+			if exists window 1 then
 				set windowReady to true
 				exit repeat
 			end if
@@ -22,9 +22,11 @@ tell application "System Events"
 	tell process "FaceTime"
 		--Open sidebar
 		repeat with buttonEl in buttons of window 1
-			if (exists attribute "AXIdentifier" of buttonEl) and (value of attribute "AXIdentifier" of buttonEl = "toggleSidebarButton") then
-				click buttonEl
-			end if
+			try
+				if (exists attribute "AXIdentifier" of buttonEl) and (value of attribute "AXIdentifier" of buttonEl = "toggleSidebarButton") then
+					click buttonEl
+				end if
+			end try
 		end repeat
 		
 		--Wait for sidebar to open
@@ -32,16 +34,23 @@ tell application "System Events"
 		
 		--Clear the clipboard
 		set the clipboard to ""
-
-		--Click "share link" button
-		set linkButton to button 2 of last group of list 1 of list 1 of scroll area 2 of window 1
-		click linkButton
-		delay 0.1
-		click menu item 1 of menu of linkButton
+		
+		# Wait for "share link" button to appear
+		repeat
+			if exists of button 2 of last group of list 1 of list 1 of scroll area 2 of window 1 then
+				--Click "share link" button
+				set linkButton to button 2 of last group of list 1 of list 1 of scroll area 2 of window 1
+				click linkButton
+				delay 0.1
+				click menu item 1 of menu of linkButton
+				exit repeat
+			end if
+			delay 0.1
+		end repeat
 		
 		set startTime to (current date)
 		repeat
-			if the clipboard is not "" then
+			if (the clipboard) is not "" then
 				return the clipboard as string
 			else if (current date) - startTime > 20 then
 				error "Clipboard timed out"

--- a/AirMessage/AppleScript/AppleScriptSource/FaceTime/getNewLink.applescript
+++ b/AirMessage/AppleScript/AppleScriptSource/FaceTime/getNewLink.applescript
@@ -16,7 +16,6 @@ tell application "System Events"
 							set windowReady to true
 							exit repeat
 						end if
-						on error
 					end try
 				end repeat
 			end if

--- a/AirMessage/AppleScript/AppleScriptSource/FaceTime/getNewLink.applescript
+++ b/AirMessage/AppleScript/AppleScriptSource/FaceTime/getNewLink.applescript
@@ -11,10 +11,13 @@ tell application "System Events"
 		repeat while not windowReady
 			if exists window 1 then
 				repeat with buttonEl in buttons of window 1
-					if (exists attribute "AXIdentifier" of buttonEl) and (value of attribute "AXIdentifier" of buttonEl contains "NS") then
-						set windowReady to true
-						exit repeat
-					end if
+					try
+						if (exists attribute "AXIdentifier" of buttonEl) and (value of attribute "AXIdentifier" of buttonEl contains "NS") then
+							set windowReady to true
+							exit repeat
+						end if
+						on error
+					end try
 				end repeat
 			end if
 			
@@ -38,7 +41,7 @@ tell application "System Events"
 		
 		set startTime to (current date)
 		repeat
-			if the clipboard is not "" then
+			if (the clipboard) is not "" then
 				return the clipboard as string
 			else if (current date) - startTime > 20 then
 				error "Clipboard timed out"

--- a/AirMessage/AppleScript/AppleScriptSource/FaceTime/initiateOutgoingCall.applescript
+++ b/AirMessage/AppleScript/AppleScriptSource/FaceTime/initiateOutgoingCall.applescript
@@ -12,11 +12,10 @@ on main(addressList)
 				if exists window 1 then
 					repeat with buttonEl in buttons of window 1
 						try
-						if (exists attribute "AXIdentifier" of buttonEl) and (value of attribute "AXIdentifier" of buttonEl contains "NS") then
-							set windowReady to true
-							exit repeat
-						end if
-						on error
+							if (exists attribute "AXIdentifier" of buttonEl) and (value of attribute "AXIdentifier" of buttonEl contains "NS") then
+								set windowReady to true
+								exit repeat
+							end if
 						end try
 					end repeat
 				end if

--- a/AirMessage/AppleScript/AppleScriptSource/FaceTime/initiateOutgoingCall.applescript
+++ b/AirMessage/AppleScript/AppleScriptSource/FaceTime/initiateOutgoingCall.applescript
@@ -11,10 +11,13 @@ on main(addressList)
 			repeat while not windowReady
 				if exists window 1 then
 					repeat with buttonEl in buttons of window 1
+						try
 						if (exists attribute "AXIdentifier" of buttonEl) and (value of attribute "AXIdentifier" of buttonEl contains "NS") then
 							set windowReady to true
 							exit repeat
 						end if
+						on error
+						end try
 					end repeat
 				end if
 				delay 0.1
@@ -44,17 +47,22 @@ on main(addressList)
 			--Wait for the request to go through
 			repeat
 				if (exists of radio group 1 of createSheet) and (enabled of radio group 1 of createSheet) then
-					delay 0.3
-					
 					--Click the create button and join the call
 					set buttonCreate to radio button 1 of radio group 1 of createSheet
-					click buttonCreate
+					
+					# FaceTime button will disable while it queries contacts, so wait for it to enable again, then click it until the sheet disappears
+					repeat while exists createSheet
+						if enabled of buttonCreate then
+							click buttonCreate
+						end if
+						delay 0.1
+					end repeat
 					
 					return true
 				else if exists button 2 of createSheet then
 					set buttonName to name of button 2 of createSheet
 					repeat with label in labelsMessages
-						if buttonName contains label
+						if buttonName contains label then
 							--Invite with Messages
 							--Dismiss the sheet
 							click button 1 of createSheet

--- a/AirMessage/AppleScript/AppleScriptSource/FaceTime/leaveCall.applescript
+++ b/AirMessage/AppleScript/AppleScriptSource/FaceTime/leaveCall.applescript
@@ -6,10 +6,12 @@ tell application "System Events"
 	tell process "FaceTime"
 		--If we're in a call, target the button with an AXIdentifier of "leaveButton"
 		repeat with buttonEl in buttons of window 1
-			if (exists attribute "AXIdentifier" of buttonEl) and (value of attribute "AXIdentifier" of buttonEl = "leaveButton") then
-				click buttonEl
-				return
-			end if
+			try
+				if (exists attribute "AXIdentifier" of buttonEl) and (value of attribute "AXIdentifier" of buttonEl = "leaveButton") then
+					click buttonEl
+					return
+				end if
+			end try
 		end repeat
 		
 		--If we're trying to make an outgoing call, target the "cancel" or "end" button
@@ -20,7 +22,7 @@ tell application "System Events"
 		if labelsCancel contains buttonName then
 			click targetButton
 			return
-		--The label is "end" if we're waiting for a pending outgoing call
+			--The label is "end" if we're waiting for a pending outgoing call
 		else if labelsEnd contains buttonName then
 			click targetButton
 			return

--- a/AirMessage/AppleScript/AppleScriptSource/FaceTime/queryIncomingCall.applescript
+++ b/AirMessage/AppleScript/AppleScriptSource/FaceTime/queryIncomingCall.applescript
@@ -9,7 +9,7 @@ tell application "System Events"
 	set notificationGroup to group 1 of UI element 1 of scroll area 1 of window 1 of application process "NotificationCenter"
 	
 	--Make sure we're dealing with a FaceTime call notification
-	if (exists static text 1 of notificationGroup) and (value of static text 1 of notificationGroup = "FaceTime") then
+	if (exists static text 1 of notificationGroup) and (value of static text 1 of notificationGroup contains "FaceTime Video") then
 		--Return the name of the caller
 		set callerName to value of static text 2 of notificationGroup
 		return callerName


### PR DESCRIPTION
@tagavari Hey, I replied to you on Discord -- these are the fixes that have eliminated those AppleScript Invalid Index errors for me.  Basically makes use of some repeat loops to detect the presence of the buttons we're looking for, and uses try catch exceptions to prevent stopping on irrelevant errors.

In the future, I might try speeding up the execution of these scripts by replacing some of the arbitrary delays with similar loops.